### PR TITLE
Fix parsing numbers in HLTB parser with K at the end

### DIFF
--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbMultiplayerTable.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbMultiplayerTable.kt
@@ -28,7 +28,7 @@ fun HltbTableParser.toMultiPlayer(): HltbMultiplayerTable {
 
 private fun HltbTableParser.getVariants(column: Map<String, String>): HltbMultiPlayerTime {
     return HltbMultiPlayerTime(
-        polled = column["Polled"]?.toLongOrNull(),
+        polled = column["Polled"]?.parseLongWithK(),
         averageSec = column["Average"]?.let { toSecondsOrNull(it) },
         medianSec = column["Median"]?.let { toSecondsOrNull(it) },
         leastSec = column["Least"]?.let { toSecondsOrNull(it) },

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbOverviewParser.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbOverviewParser.kt
@@ -120,3 +120,4 @@ class HltbOverviewParser(private val html: Document) {
         return dateFormat.parse(parent.ownText()).time
     }
 }
+

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbPlatformTable.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbPlatformTable.kt
@@ -227,7 +227,7 @@ fun HltbTableParser.toPlatform(): HltbPlatformTable {
 
 private fun HltbTableParser.getVariants(column: Map<String, String>): HltbPlatformTime {
     return HltbPlatformTime(
-        polled = column["Polled"]?.toLongOrNull(),
+        polled = column["Polled"]?.parseLongWithK(),
         mainSec = column["Main"]?.let { toSecondsOrNull(it) },
         extraSec = column["Main +"]?.let { toSecondsOrNull(it) },
         completionistSec = column["100%"]?.let { toSecondsOrNull(it) },

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbSingleplayerTable.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbSingleplayerTable.kt
@@ -32,7 +32,7 @@ fun HltbTableParser.toSingleplayer(): HltbSingleplayerTable {
 
 private fun HltbTableParser.getVariants(column: Map<String, String>): HltbSinglePlayerTime {
     return HltbSinglePlayerTime(
-        polled = column["Polled"]?.toLongOrNull(),
+        polled = column["Polled"]?.parseLongWithK(),
         averageSec = column["Average"]?.let { toSecondsOrNull(it) },
         medianSec = column["Median"]?.let { toSecondsOrNull(it) },
         rushedSec = column["Rushed"]?.let { toSecondsOrNull(it) },

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbSpeedrunTable.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbSpeedrunTable.kt
@@ -28,7 +28,7 @@ fun HltbTableParser.toSpeedrun(): HltbSpeedrunTable {
 
 private fun HltbTableParser.getVariants(column: Map<String, String>): HltbSpeedrunTime {
     return HltbSpeedrunTime(
-        polled = column["Polled"]?.toLongOrNull(),
+        polled = column["Polled"]?.parseLongWithK(),
         averageSec = column["Average"]?.let { toSecondsOrNull(it) },
         medianSec = column["Median"]?.let { toSecondsOrNull(it) },
         leastSec = column["Fastest"]?.let { toSecondsOrNull(it) },

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
@@ -9,14 +9,14 @@ private fun parseStringWithKtoLong(string: String): Long? {
         return withoutKparse
     }
 
-    val exponent = "\\d+(?=(.|)\\d+k)"
+    val exponent = "\\d+(?=(.|)\\d+(K|k))"
         .toRegex()
         .find(string)
         ?.value
         ?.toLongOrNull()
         ?.times(1000)
 
-    val mantissa = "(?<=\\d(\\.|))\\d+(?=k)"
+    val mantissa = "(?<=\\d(\\.|))\\d+(?=(K|k))"
         .toRegex()
         .find(string)
         ?.value

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
@@ -1,0 +1,61 @@
+package io.github.darefox.hltbproxy.hltb
+
+import java.lang.NumberFormatException
+
+private fun parseLongWithK(string: String): Long? {
+    val withoutKparse = "^\\d*\$".toRegex().find(string)?.value?.toLongOrNull()
+
+    if (withoutKparse != null) {
+        return withoutKparse
+    }
+
+    val exponent = "\\d+(?=(.|)\\d+k)"
+        .toRegex()
+        .find(string)
+        ?.value
+        ?.toLongOrNull()
+        ?.times(1000)
+
+    val mantissa = "(?<=\\d(\\.|))\\d+(?=k)"
+        .toRegex()
+        .find(string)
+        ?.value
+        ?.toLongOrNull()
+        ?.times(100)
+
+    return (mantissa ?: 0) + (exponent ?: 0)
+}
+
+/**
+ * Parse numbers with K at the end
+ *
+ * Example
+ * ```
+ * "1.3k".parseLongWithK() == 1300
+ * "13".parseLongWithK() == 13
+ * "k13".parseLongWithK() == null
+ * ```
+ */
+fun String.parseLongWithK(): Long? {
+    return parseLongWithK(this)
+}
+
+/**
+ * Parse numbers with K at the end
+ *
+ * Example
+ * ```
+ * "1.3k".parseIntWithK() == 1300
+ * "13".parseIntWithK() == 13
+ * "k13".parseIntWithK() == null
+ * ```
+ */
+fun String.parseIntWithK(): Int? {
+    val result = parseLongWithK(this) ?: return null
+
+    if (result !in Int.MIN_VALUE..Int.MAX_VALUE) {
+        throw NumberFormatException("$result is not in range of Int")
+    }
+
+    return result.toInt()
+}

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/ParseNumberWithK.kt
@@ -2,7 +2,7 @@ package io.github.darefox.hltbproxy.hltb
 
 import java.lang.NumberFormatException
 
-private fun parseLongWithK(string: String): Long? {
+private fun parseStringWithKtoLong(string: String): Long? {
     val withoutKparse = "^\\d*\$".toRegex().find(string)?.value?.toLongOrNull()
 
     if (withoutKparse != null) {
@@ -37,7 +37,7 @@ private fun parseLongWithK(string: String): Long? {
  * ```
  */
 fun String.parseLongWithK(): Long? {
-    return parseLongWithK(this)
+    return parseStringWithKtoLong(this)
 }
 
 /**
@@ -51,7 +51,7 @@ fun String.parseLongWithK(): Long? {
  * ```
  */
 fun String.parseIntWithK(): Int? {
-    val result = parseLongWithK(this) ?: return null
+    val result = parseStringWithKtoLong(this) ?: return null
 
     if (result !in Int.MIN_VALUE..Int.MAX_VALUE) {
         throw NumberFormatException("$result is not in range of Int")


### PR DESCRIPTION
Example: `1.3k` polled will be parsed to `1300` instead of `null`