### PR TITLE
Fix  "Field 'count' is required for type with serial name"

### DIFF
--- a/src/main/kotlin/io/github/darefox/hltbproxy/Date.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/Date.kt
@@ -12,11 +12,12 @@ import java.util.*
  */
 fun List<SimpleDateFormat>.parse(string: String): Date {
     var ex: ParseException? = null
-    lateinit var result: Date
 
     for (dateFormat in this) {
         try {
-            return dateFormat.parse(string)
+            // not inlined for debugging
+            val result = dateFormat.parse(string)
+            return result
         } catch (caught: ParseException) {
             ex = caught
         }

--- a/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbQueryResponse.kt
+++ b/src/main/kotlin/io/github/darefox/hltbproxy/hltb/HltbQueryResponse.kt
@@ -16,7 +16,6 @@ data class HltbQueryResponse(
 
 @Serializable
 data class HltbGameData(
-    val count: Long,
     @JsonNames("game_id")
     val gameId: Long,
     @JsonNames("game_name")


### PR DESCRIPTION
### HLTB stopped responding game data with `count` field and that made proxy throw error on query

![image](https://github.com/DareFox/HowLongToBeat-Proxy-API/assets/47672780/951d5190-6383-4c4c-9066-3d253e322ca8)

### Solution: drop `count` field from parsing