### PR TITLE
fix(hltb): Update search URL to /s

### DIFF
--- a/hltb-scraping/src/main/kotlin/HLTB.kt
+++ b/hltb-scraping/src/main/kotlin/HLTB.kt
@@ -32,7 +32,7 @@ object HLTB {
         var keyIsNotUpdated = true
         lateinit var response: Response
         while (true) {
-            val request = Request(POST, "https://howlongtobeat.com/api/lookup/${getSearchKey()}")
+            val request = Request(POST, "https://howlongtobeat.com/api/s/${getSearchKey()}")
                 .hltbJsonRequest(url, queryObj)
             val call = httpClient(request)
 
@@ -151,7 +151,7 @@ object HLTB {
     }
 
     private fun findKeyInScripts(scripts: Sequence<String>): String {
-        val fetchLineRegex = "(?<=api/lookup/).*?,".toRegex()
+        val fetchLineRegex = "(?<=api/s/).*?,".toRegex()
         val concatValuesRegex = "(?<=concat\\(\").*?(?=\")".toRegex()
         for (script in scripts) {
             val fetchLine = fetchLineRegex.find(script) ?: continue

--- a/hltb-scraping/src/main/kotlin/HLTB.kt
+++ b/hltb-scraping/src/main/kotlin/HLTB.kt
@@ -32,7 +32,7 @@ object HLTB {
         var keyIsNotUpdated = true
         lateinit var response: Response
         while (true) {
-            val request = Request(POST, "https://howlongtobeat.com/api/find/${getSearchKey()}")
+            val request = Request(POST, "https://howlongtobeat.com/api/lookup/${getSearchKey()}")
                 .hltbJsonRequest(url, queryObj)
             val call = httpClient(request)
 
@@ -151,7 +151,7 @@ object HLTB {
     }
 
     private fun findKeyInScripts(scripts: Sequence<String>): String {
-        val fetchLineRegex = "(?<=api/find/).*?,".toRegex()
+        val fetchLineRegex = "(?<=api/lookup/).*?,".toRegex()
         val concatValuesRegex = "(?<=concat\\(\").*?(?=\")".toRegex()
         for (script in scripts) {
             val fetchLine = fetchLineRegex.find(script) ?: continue


### PR DESCRIPTION
Just harmonizing the changes the Python Project has been doing (as per -> ScrappyCocco/HowLongToBeat-PythonAPI#38 )

Changes the Search URL from find/ to lookup/

Might be time to add all these keys into an array [find, lookup, search, ???] and loop through them in case they change it again