### PR TITLE
fix(systemTest): Do not cache test results

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -57,6 +57,7 @@ testing.suites.register<JvmTestSuite>("systemTest") {
             }
             shouldRunAfter("test")
             finalizedBy(markdownReportTask)
+            outputs.upToDateWhen { false } // DO NOT CACHE TESTS
         }
     }
 }


### PR DESCRIPTION
What is point of testing current parsing state, if we load previous state?